### PR TITLE
Update Seller.php

### DIFF
--- a/src/Seller.php
+++ b/src/Seller.php
@@ -514,7 +514,6 @@ class Seller
             'verificationId' => $this->verificationId,
             'accountNumberRequested' => $this->accountNumberRequested,
             'payoutDataVerificationType' => $this->payoutDataVerificationType,
-            'expireDate' => $this->expireDate,
             'verified' => $this->verified,
         ];
 

--- a/src/Seller.php
+++ b/src/Seller.php
@@ -588,7 +588,7 @@ class Seller
 
         $data = [
             'verificationId' => $this->verificationId,
-            'currency' => $currency,
+            'transferCurrency' => $currency,
             'email' => $email,
         ];
 


### PR DESCRIPTION
Accoring to the doc:
> 3.6.1. Verification transfer service
> In order to verify payouts data with use of verification transfer service there is a need to
> follow the steps:
> 1. Submerchant must declare the bank account number used for withdrawals
> 2. Send the request to create order for verification transfer:
```
POST /verification-transfers/manual
{
 "verificationId": "verification-123",
 "transferCurrency": "PLN",
 "email": "user@example.com"
}
```